### PR TITLE
Fix throwing parse error in Edge

### DIFF
--- a/DrawingTools/Drawing.js
+++ b/DrawingTools/Drawing.js
@@ -158,7 +158,7 @@ class FurnaceDrawing extends Drawing {
           this.bg = this.addChild(new PIXI.Container());
           this.bg.tile = this.bg.addChild(sprite)
         }
-      } catch (_){
+      } catch (err) {
         this.texture = null;
         this.bg = null;
       }

--- a/DrawingTools/Drawing.js
+++ b/DrawingTools/Drawing.js
@@ -158,7 +158,7 @@ class FurnaceDrawing extends Drawing {
           this.bg = this.addChild(new PIXI.Container());
           this.bg.tile = this.bg.addChild(sprite)
         }
-      } catch {
+      } catch (_){
         this.texture = null;
         this.bg = null;
       }


### PR DESCRIPTION
Before:
`SCRIPT1005: SCRIPT1005: Expected '('               Drawing.js (161,15)`
and 
![image](https://user-images.githubusercontent.com/24963659/78452419-686e3f80-7648-11ea-9ce1-cc8dd2e36bd4.png)

After:
No Furnace errors