### PR TITLE
Bind the execution of script macros to the macro

### DIFF
--- a/Macros/Macros.js
+++ b/Macros/Macros.js
@@ -171,7 +171,7 @@ class FurnaceMacros {
         return (new Function(`"use strict";
             return (${asyncFunction} function ({speaker, actor, token, character, args, scene}={}) {
                 ${this.data.command}
-                });`))()(context);
+                });`))().call(this, context);
     }
 
     renderMacro(...args) {


### PR DESCRIPTION
In Foundry (core), `this` is available inside script macros with a reference to the macro that is being executed.
To enable this behaviour, we must bind the returned function to the macro (in this context `this`) before executing it with the `context`..