### PR TITLE
Add support for splitting nested journals

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -31,6 +31,7 @@
     "FURNACE.SPLIT.contextMenu": "Split Journal",
     "FURNACE.SPLIT.description": "Split the journal entry '{name}' into multiple entries.",
     "FURNACE.SPLIT.splitOn": "Split on",
+    "FURNACE.SPLIT.splitDepth": "Split depth",
     "FURNACE.SPLIT.newEntries": "New journal entries ({numEntries}) :",
     "FURNACE.SPLIT.separateHeader": "Include page header in each new journal entry",
     "FURNACE.SPLIT.includeImage": "Include Journal's image in each new entry",

--- a/templates/split-journal.html
+++ b/templates/split-journal.html
@@ -29,6 +29,16 @@
             </select>
         </div>
         <div class="form-group">
+            <label>{{localize "FURNACE.SPLIT.splitDepth"}}</label>
+            <select name="splitterDepth" data-dtype="String">
+                {{#select useSplitterDepth}}
+                {{#each splitters as |splitter s|}}
+                <option value="{{s}}">{{splitter}}</option>
+                {{/each}}
+                {{/select}}
+            </select>
+        </div>
+        <div class="form-group">
             <div>
                 {{localize "FURNACE.SPLIT.newEntries" numEntries=newEntries.length}}
             </div>


### PR DESCRIPTION
Closes #73 

This allows the user to journals across multiple levels of hierarchy. The user specifies the upper and lower bounds of the split. 

If the upper and lower are set to the same value, I've confirmed that functionality remains identical to the current state.  